### PR TITLE
Some improvements to be more in line with PHP standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 script:
   - pyrus install pear/PHP_CodeSniffer
   - phpenv rehash
-  - phpcs ./app
+  - phpcs --standard=PSR2 ./app ./src
     
 notifications:
   email:

--- a/app/callback.php
+++ b/app/callback.php
@@ -2,7 +2,7 @@
 /**
  *  Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license.
  *  See LICENSE in the project root for license information.
- * 
+ *
  *  PHP version 5
  *
  *  @category Code_Sample
@@ -17,12 +17,15 @@
               Azure Active Directory (AD) finishes the authentication flow.
  */
 
-namespace Microsoft\Office365\UnifiedAPI\Connect;
+require_once('../autoload.php');
 
+use Microsoft\Office365\UnifiedAPI\Connect\AuthenticationManager;
+
+//We store user name, id, and tokens in session variables
 if (session_status() == PHP_SESSION_NONE) {
     session_start();
 }
-require_once 'AuthenticationManager.php';
+
 
 // Get the authorization code and other parameters from the query string
 // and store them in the session.
@@ -41,15 +44,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['code'])) {
     }
     
     // With the authorization code, we can retrieve access tokens and other data.
-    try 
-    {
+    try {
         AuthenticationManager::acquireToken();
         header('Location: sendmail.php');
         exit();
-    } 
-    catch (\RuntimeException $e)
-    {
+    } catch (\RuntimeException $e) {
         echo 'Something went wrong, couldn\'t get tokens: ' . $e->getMessage();
     }
 }
-?>

--- a/app/disconnect.php
+++ b/app/disconnect.php
@@ -2,7 +2,7 @@
 /**
  *  Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license.
  *  See LICENSE in the project root for license information.
- * 
+ *
  *  PHP version 5
  *
  *  @category Code_Sample
@@ -16,9 +16,8 @@
     @abstract Users are redirected to this page to initiate the disconnect flow
  */
 
-namespace Microsoft\Office365\UnifiedAPI\Connect;
+require_once('../autoload.php');
 
-require_once 'AuthenticationManager.php';
+use Microsoft\Office365\UnifiedAPI\Connect\AuthenticationManager;
 
 AuthenticationManager::disconnect();
-?>

--- a/app/index.php
+++ b/app/index.php
@@ -2,7 +2,7 @@
 /**
  *  Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license.
  *  See LICENSE in the project root for license information.
- * 
+ *
  *  PHP version 5
  *
  *  @category Code_Sample
@@ -17,9 +17,9 @@
               the "connect" button.
  */
 
-namespace Microsoft\Office365\UnifiedAPI\Connect;
+require_once '../autoload.php';
 
-require_once'AuthenticationManager.php';
+use Microsoft\Office365\UnifiedAPI\Connect\AuthenticationManager;
 
 // User clicked the "connect" button. Start the authentication flow.
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/app/sendmail.php
+++ b/app/sendmail.php
@@ -2,7 +2,7 @@
 /**
  *  Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license.
  *  See LICENSE in the project root for license information.
- * 
+ *
  *  PHP version 5
  *
  *  @category Code_Sample
@@ -17,17 +17,18 @@
               The page offers UI to send a welcome email to the specified account. 
  */
 
-namespace Microsoft\Office365\UnifiedAPI\Connect;
+require_once("../autoload.php");
+
+use Microsoft\Office365\UnifiedAPI\Connect\MailManager;
 
 //We store user name, id, and tokens in session variables
 if (session_status() == PHP_SESSION_NONE) {
     session_start();
 }
-require_once 'MailManager.php';
 
 // Use the given name if it exists, otherwise, use the alias
-$greetingName = isset($_SESSION['given_name']) 
-                ? $_SESSION['given_name'] 
+$greetingName = isset($_SESSION['given_name'])
+                ? $_SESSION['given_name']
                 : explode('@', $_SESSION['unique_name'])[0];
 
 ?>
@@ -89,12 +90,11 @@ $greetingName = isset($_SESSION['given_name'])
         </button>
         <div>
             <?php
-                // The user clicked the "Send mail" button 
+                // The user clicked the "Send mail" button
             if ($_SERVER['REQUEST_METHOD'] === 'POST'
                 && isset($_POST['recipient'])
             ) {
-                try
-                {
+                try {
                     MailManager::sendWelcomeMail($_POST['recipient']);
             ?>
                         <p 
@@ -103,15 +103,13 @@ $greetingName = isset($_SESSION['given_name'])
                             <?php echo $_POST['recipient']; ?>!
                         </p>
             <?php
-                } 
-                catch (\RuntimeException $e) 
-                {
-            ?>
+                } catch (\RuntimeException $e) {
+                ?>
                         <p 
                             class="ms-font-m ms-fontColor-redDark">
-                            Something went wrong, couldn't send an email.
+                            Something went wrong, couldn't send an email. <?php echo $e->getMessage(); ?>
                         </p>
-            <?php            
+            <?php
                 }
             }
             ?>

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * An example of a project-specific implementation.
+ *
+ * After registering this autoload function with SPL, the following line
+ * would cause the function to attempt to load the \Foo\Bar\Baz\Qux class
+ * from /path/to/project/src/Baz/Qux.php:
+ *
+ *      new \Foo\Bar\Baz\Qux;
+ *
+ * @param string $class The fully-qualified class name.
+ * @return void
+ */
+spl_autoload_register(function ($class) {
+
+    // project-specific namespace prefix
+    $prefix = 'Microsoft\\Office365\\UnifiedAPI\\Connect\\';
+
+    // base directory for the namespace prefix
+    $base_dir = __DIR__ . '/src/';
+
+    // does the class use the namespace prefix?
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        // no, move to the next registered autoloader
+        return;
+    }
+
+    // get the relative class name
+    $relative_class = substr($class, $len);
+
+    // replace the namespace prefix with the base directory, replace namespace
+    // separators with directory separators in the relative class name, append
+    // with .php
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+    // if the file exists, require it
+    if (file_exists($file)) {
+        require $file;
+    }
+});

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload": {
+        "psr-4": {
+            "Microsoft\\Office365\\UnifiedAPI\\Connect\\": "src/"
+        }
+    }
+}

--- a/src/AuthenticationManager.php
+++ b/src/AuthenticationManager.php
@@ -2,7 +2,7 @@
 /**
  *  Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license.
  *  See LICENSE in the project root for license information.
- * 
+ *
  *  PHP version 5
  *
  *  @category Code_Sample
@@ -17,18 +17,10 @@
  */
  
 namespace Microsoft\Office365\UnifiedAPI\Connect;
- 
-// We use the session to store tokens and data about the user. 
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
 
-require_once 'Constants.php';
-require_once 'RequestManager.php';
-
-/** 
- *  Provides methods to authenticate to Azure AD and 
- *  store tokens and user information 
+/**
+ *  Provides methods to authenticate to Azure AD and
+ *  store tokens and user information
  *
  *  @class    AuthenticationManager
  *  @category Code_Sample
@@ -40,8 +32,8 @@ require_once 'RequestManager.php';
 class AuthenticationManager
 {
     /**
-     *  Starts the authentication flow. At the end, 
-     *  the user should be redirected to callback.php 
+     *  Starts the authentication flow. At the end,
+     *  the user should be redirected to callback.php
      *
      *  @function connect
      *  @return   Nothing, redirects browser to authorize endpoint
@@ -50,9 +42,9 @@ class AuthenticationManager
     {
         // Redirect the browser to the authorization endpoint. Auth endpoint is
         // https://login.microsoftonline.com/common/oauth2/authorize
-        $redirect = Constants::AUTHORITY_URL . Constants::AUTHORIZE_ENDPOINT . 
-                    '?response_type=code' . 
-                    '&client_id=' . urlencode(Constants::CLIENT_ID) . 
+        $redirect = Constants::AUTHORITY_URL . Constants::AUTHORIZE_ENDPOINT .
+                    '?response_type=code' .
+                    '&client_id=' . urlencode(Constants::CLIENT_ID) .
                     '&redirect_uri=' . urlencode(Constants::REDIRECT_URI);
         header("Location: {$redirect}");
         exit();
@@ -60,9 +52,9 @@ class AuthenticationManager
     
     /**
      *  Contacts the token endpoint to get OAuth tokens including an access token
-     *  that can be used to send an authenticated request to the 
+     *  that can be used to send an authenticated request to the
      *  Microsoft Graph.
-     *  It also stores user information, like given name, in session variables. 
+     *  It also stores user information, like given name, in session variables.
      *
      *  @function acquireToken
      *  @return   Nothing, stores tokens in session variables.
@@ -75,7 +67,7 @@ class AuthenticationManager
         // Token endpoint is:
         // https://login.microsoftonline.com/common/oauth2/token
         $response = RequestManager::sendPostRequest(
-            $tokenEndpoint, 
+            $tokenEndpoint,
             array(),
             array(
                 'client_id' => Constants::CLIENT_ID,
@@ -99,15 +91,15 @@ class AuthenticationManager
         // resource - The App ID URI of the web API (secured resource).
         // scope - Impersonation permissions granted to the client application.
         // token_type - Indicates the token type value.
-        foreach ($jsonResponse as $key=>$value) {
+        foreach ($jsonResponse as $key => $value) {
             $_SESSION[$key] = $value;
         }
         
         // The id token is a JWT token that contains information about the user
-        // It's a base64 coded string that has a header and payload 
+        // It's a base64 coded string that has a header and payload
         $decodedAccessTokenPayload = base64_decode(
             explode('.', $_SESSION['id_token'])[1]
-        );            
+        );
         $jsonAccessTokenPayload = json_decode($decodedAccessTokenPayload, true);
         
         // The id token payload has the following parameters:
@@ -118,20 +110,20 @@ class AuthenticationManager
         // iat - Issued at time.
         // iss - Identifies the token issuer.
         // nbf - Not before time. The time when the token becomes effective.
-        // oid - Object identifier (ID) of the user object 
+        // oid - Object identifier (ID) of the user object
         //       in Azure Active Directory (AD).
         // sub - Token subject identifier.
         // tid - Tenant identifier of the Azure AD tenant that issued the token.
         // unique_name - A unique identifier that can be displayed to the user.
         // upn - User principal name.
         // ver - Version.
-        foreach ($jsonAccessTokenPayload as $key=>$value) {
+        foreach ($jsonAccessTokenPayload as $key => $value) {
             $_SESSION[$key] = $value;
         }
     }
     
     /**
-     *  Clear the session and redirect the browser to Azure logout endpoint. 
+     *  Clear the session and redirect the browser to Azure logout endpoint.
      *
      *  @function disconnect
      *  @return   Nothing, redirects browser to Connect.php page.
@@ -142,23 +134,22 @@ class AuthenticationManager
         
         $connectUrl = (@$_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://';
         $connectUrl .= $_SERVER['SERVER_NAME'] . ':' .
-            $_SERVER['SERVER_PORT'] . 
+            $_SERVER['SERVER_PORT'] .
             $_SERVER['REQUEST_URI'];
         
         // Get the full URL of the index.php page to send it to the logout endpoint
         $connectUrl = substr(
-            $connectUrl, 
-            0, 
+            $connectUrl,
+            0,
             strrpos($connectUrl, '/')
         ) . '/index.php';
 
         // Logout endpoint is in the form
         // https://login.microsoftonline.com/common/oauth2/logout
-        // ?post_logout_redirect_uri=<full_url_of_your_start_page> 
-        $redirect = Constants::AUTHORITY_URL . Constants::LOGOUT_ENDPOINT . 
+        // ?post_logout_redirect_uri=<full_url_of_your_start_page>
+        $redirect = Constants::AUTHORITY_URL . Constants::LOGOUT_ENDPOINT .
                     '?post_logout_redirect_uri=' . urlencode($connectUrl);
         header("Location: " . $redirect);
         exit();
     }
 }
-?>

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -2,7 +2,7 @@
 /**
  *  Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license.
  *  See LICENSE in the project root for license information.
- * 
+ *
  *  PHP version 5
  *
  *  @category Code_Sample
@@ -14,8 +14,8 @@
 
 namespace Microsoft\Office365\UnifiedAPI\Connect;
  
-/** 
- *  Stores constant and configuration values used through the app 
+/**
+ *  Stores constant and configuration values used through the app
  *
  *  @class    Constants
  *  @category Code_Sample
@@ -36,4 +36,3 @@ class Constants
     const RESOURCE_ID = 'https://graph.microsoft.com';
     const SENDMAIL_ENDPOINT = '/v1.0/me/microsoft.graph.sendmail';
 }
-?>

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Microsoft\Office365\UnifiedAPI\Connect;
+
+class Exception extends \RuntimeException
+{
+
+}

--- a/src/MailManager.php
+++ b/src/MailManager.php
@@ -2,7 +2,7 @@
 /**
  *  Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license.
  *  See LICENSE in the project root for license information.
- * 
+ *
  *  PHP version 5
  *
  *  @category Code_Sample
@@ -14,14 +14,8 @@
 
 namespace Microsoft\Office365\UnifiedAPI\Connect;
 
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
-require_once 'Constants.php';
-require_once 'RequestManager.php';
-
-/** 
- *  Handles the creation of the email and sends the request 
+/**
+ *  Handles the creation of the email and sends the request
  *  to the Office 365 unified endpoint
  *
  *  @class    MailManager
@@ -35,7 +29,7 @@ class MailManager
 {
     
     /**
-     *  Builds the email message and uses RequestManager to send a POST request 
+     *  Builds the email message and uses RequestManager to send a POST request
      *  to the sendmail endpoint in the Microsoft Graph.
      *
      *  @param string $recipient The recipient of the email.
@@ -49,7 +43,7 @@ class MailManager
         
         // Use the given name if it exists, otherwise, use the alias
         $greetingName = isset($_SESSION['given_name'])
-                        ? $_SESSION['given_name'] 
+                        ? $_SESSION['given_name']
                         : explode('@', $_SESSION['unique_name'])[0];
 
         $emailBody = str_replace(
@@ -77,7 +71,7 @@ class MailManager
             SaveToSentItems: true
             }";
             
-        // Send the email request to the sendmail endpoint, 
+        // Send the email request to the sendmail endpoint,
         // which is in the following URI:
         // https://graph.microsoft.com/v1.0/me/microsoft.graph.sendmail
         // Note that the access token is attached in the Authorization header
@@ -85,7 +79,7 @@ class MailManager
             Constants::RESOURCE_ID . Constants::SENDMAIL_ENDPOINT,
             array(
                 'Authorization: Bearer ' . $_SESSION['access_token'],
-                'Content-Type: application/json;' . 
+                'Content-Type: application/json;' .
                               'odata.metadata=minimal;' .
                               'odata.streaming=true'
             ),
@@ -93,5 +87,3 @@ class MailManager
         );
     }
 }
-?>
-


### PR DESCRIPTION
Michael Mainer linked me to this repository to take a look through it, and I thought I might make some improvements on this code base to bring it more in line with PHP standards, and to make it more usable in some cases. Here's a list of changes I made

 * Moved the classes to a `src/` folder, to create a better separation of Domain Code and Application Code
 * Added PSR-4 autoloading through the `autoload.php`
 * Added a `composer.json` so that if this were to be required as a composer package (For the connection manager for example), then composer can handle the autoloading
 * Moved the session starts out of the Domain Code and kept it in the Application Code
 * Made the code PSR-2 compliant (code styling fix)
 * Changes the phpcs check in travis to sniff against PSR-2. Great that it was there in the first place, but PSR-2 is the closest thing to a style standard that PHP has
 * Turned off CURL failing on HTTP Errors. By failing, it didn't allow you to retrieve the body of the request. Since the body of the failed requests contain useful information passed back from O365 (Empty Bearer for example, as opposed to just a 401), it makes more sense to throw an exception with this information instead of just with the curl header
 * Added a `Microsoft\Office365\UnifiedAPI\Connect\Exception` class. This way you can catch and handle errors specific to the Connection rather than just all Runtime Exceptions

I would have liked to do more, but I didn't want to go changing much more of the example without checking if it was okay first. The above are changes that I figured would have no issue getting merged in, while the below are things that I think would be useful to be merged in, but might not make it. Let me know if any of them sound good to you guys, and I can make a separate PR for them

 * Remove the `autoload.php` file. Preferably composer should be used to do the autoloading, but I didn't want to introduce a new requirement for using this demo application, even if composer is the standard in PHP
 * Add a `"start": "php -S localhost:8000 -t app/"` script to the `composer.json` file, so that running the demo is simplified to `composer run start`. I didn't add it for the same reason as above
 * `CLIENT_ID` and `CLIENT_SECRET` should be injected in to the classes through the constructors as opposed to stored in a constants file. Ideally all of the code in `src/` should be completely independent of any specific application concerns. Ideally it should be in a state where you can just register it on packagist and let people `composer require` the package, and using it like any other library
 * Likewise, the access `MailManager` shouldn't be retrieving any variables from the session, but rather those variables should be passed in through the constructor or through arguments.
 * Similarly, the `AuthenticationManager::connect()` function shouldn't set items to the session, but rather return the data retrieved from the payload. It should be an application concern as to how the data is stored
 * The `AuthenticationManager::disconnect()` function shouldn't destroy the session, for the reasons above. An application may want to disconnect a user from O365 but still keep them logged in to that application

I hope you find this PR acceptable. If you have any questions or comments, let me know